### PR TITLE
Fix issue showing xml_child_name

### DIFF
--- a/map2xml.go
+++ b/map2xml.go
@@ -116,6 +116,9 @@ func handleChildren(e *xml.Encoder, fieldName string, v interface{}, cdata bool)
 	} else if reflect.TypeOf(v).Kind() == reflect.Map {
 		e.EncodeToken(xml.StartElement{Name: xml.Name{Local: fieldName}})
 		for key, val := range v.(map[string]interface{}) {
+			if key == "xml_child_name" {
+				continue
+			}
 			handleChildren(e, key, val, cdata)
 		}
 		return e.EncodeToken(xml.EndElement{Name: xml.Name{Local: fieldName}})


### PR DESCRIPTION
hides 'xml_child_name' from slice

```xml
<slices>
  <slice>
    <xml_child_name>slice</xml_child_name>
    <one>1</one>
  </slice>
  <slice>
    <two>2</two>
  </slice>
  <slice>
    <three>3</three>
  </slice>
</slices>
```

to 

```xml
<slices>
  <slice>
    <one>1</one>
  </slice>
  <slice>
    <two>2</two>
  </slice>
  <slice>
    <three>3</three>
  </slice>
</slices>
```